### PR TITLE
:sparkles: Allow username change depending on user settings

### DIFF
--- a/app/Http/Controllers/AccountSettingsController.php
+++ b/app/Http/Controllers/AccountSettingsController.php
@@ -11,21 +11,29 @@ class AccountSettingsController extends Controller
     public function edit()
     {
         return view('user.settings.account', [
-            'user' => Auth::user(),
+            'user' => Auth::user()->load('settings'),
         ]);
     }
 
     public function update(RconService $rcon, AccountSettingsFormRequest $request)
     {
-        $request->validated();
-
         $user = Auth::user();
-        if ($user->online && $user->username !== $request->input('username')) {
+
+        if ($user->online && ($user->settings->allow_name_change && $user->username !== $request->input('username'))) {
             $rcon->disconnectUser($user);
             sleep(2);
         }
 
-        Auth::user()->update($request->except('motto'));
+        if ($user->settings->allow_name_change) {
+            $user->update([
+                'mail' => $request->input('mail'),
+                'username' => $request->input('username'),
+            ]);
+        } else {
+            $user->update([
+                'mail' => $request->input('mail'),
+            ]);
+        }
 
         if ($user->motto !== $request->input('motto')) {
             $rcon->setMotto($user, $request->input('motto'));

--- a/app/Http/Requests/AccountSettingsFormRequest.php
+++ b/app/Http/Requests/AccountSettingsFormRequest.php
@@ -11,7 +11,7 @@ class AccountSettingsFormRequest extends FormRequest
     {
         return [
             'mail' => ['required', 'email', Rule::unique('users')->ignore($this->user()->id)],
-            'username' => ['required', 'string', 'max:25', Rule::unique('users')->ignore($this->user()->id)],
+            'username' => ['sometimes', 'string', 'regex:/^[a-zA-Z0-9_.-]+$/u', 'min:3', 'max:25', Rule::unique('users')->ignore($this->user()->id)],
             'motto' => ['nullable', 'string', 'max:127'],
         ];
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -97,6 +97,11 @@ class User extends Authenticatable
         return $this->hasOne(Ban::class, 'user_id')->where('ban_expire', '>', time());
     }
 
+    public function settings(): HasOne
+    {
+        return $this->hasOne(UserSetting::class);
+    }
+
     public function ssoTicket(): string
     {
         $sso = sprintf("%s-%s", setting('hotel_name'), Str::uuid());

--- a/app/Models/UserSetting.php
+++ b/app/Models/UserSetting.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserSetting extends Model
+{
+    protected $table = 'users_settings';
+    protected $guarded = ['id'];
+    public $timestamps = false;
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/resources/themes/atom/views/user/settings/account.blade.php
+++ b/resources/themes/atom/views/user/settings/account.blade.php
@@ -25,17 +25,19 @@
                     <x-form.input name="mail" type="email" value="{{ $user->mail }}" :autofocus="true" />
                 </div>
 
-                <div class="flex flex-col gap-y-1">
-                    <x-form.label for="username">
-                        {{ __('Username') }}
+                @if($user->settings->allow_name_change)
+                    <div class="flex flex-col gap-y-1">
+                        <x-form.label for="username">
+                            {{ __('Username') }}
 
-                        <x-slot:info>
-                            {{ __('Your username is what you and others will see in-game') }}
-                        </x-slot:info>
-                    </x-form.label>
+                            <x-slot:info>
+                                {{ __('Your username is what you and others will see in-game') }}
+                            </x-slot:info>
+                        </x-form.label>
 
-                    <x-form.input name="username" value="{{ $user->username }}" />
-                </div>
+                        <x-form.input name="username" value="{{ $user->username }}" />
+                    </div>
+                @endif
 
                 <div class="flex flex-col gap-y-1">
                     <x-form.label for="motto">


### PR DESCRIPTION
This PR will only allow username change, when the "allow_name_change" is set to "1" in the user_settings table.

It also fixes an issue where HTML is allowed within the username, causing issue on the nitro client