### PR TITLE
:bug: Fix issue with account settings

### DIFF
--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -4,11 +4,14 @@ namespace App\Observers;
 
 use App\Models\User;
 use App\Models\UserCurrency;
+use App\Models\UserSetting;
 
 class UserObserver
 {
     public function created(User $user)
     {
+        $user->settings()->create();
+
         UserCurrency::query()->insert([
             [
                 'user_id' => $user->id,


### PR DESCRIPTION
This PR fixes an issue, where users wouldn't be able to enter "Account settings" on the CMS if they had never been on the client, due to missing "users_settings" entry.