### PR TITLE
:sparkles: Add option to automatically sort colliding table names & f…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,6 @@ SWF_PATH=
 
 FINDRETROS_NAME=
 FINDRETROS_ENABLED=false
+
+# If set to true, Atom will rename any colliding table names when migration the first time around
+RENAME_COLLIDING_TABLES=false

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Atom CMS was made to bring the retro community a variation to the CMS options ou
 
 Laravel was chosen as its backend, due to it being robust and battle tested "in the real world" on top up that it has a huge community to back it, with tons of free (& paid) learning resources and its solid documentation that other CMS' normally lack. Combine those things together and you'll be able to build anything you want even as a beginner, you dont need to be a PHP expert or a frontend master to work with Atom CMS!
 
+## Coming from another cms?
+Atom CMS has a built in option to rename colliding table names and drop matching foreign keys.
+
+For example if you're changing from Cosmic CMS and you know beforehand that your database contains similar table names, all you have to do is changing the ``RENAME_COLLIDING_TABLES=false`` to ``RENAME_COLLIDING_TABLES=true`` inside of the ``.env`` file.
+
 ## Setup guide
 To install Atom CMS you'll need to do the following:
 - PHP 8.1 or above [PHP Downloads](https://www.php.net/downloads.php)

--- a/config/habbo.php
+++ b/config/habbo.php
@@ -1,9 +1,11 @@
 <?php
 
 return [
-    /**
-     * Rcon configuration.
-     */
+    'migrations' => [
+        // Only set this to true in the .env file if your CERTAIN that you want to rename coliding table names
+        'rename_tables' => env('RENAME_COLLIDING_TABLES', false)
+    ],
+
     'rcon' => [
         'host' => env('RCON_HOST', '127.0.0.1'),
         'port' => env('RCON_PORT', 3001),

--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -13,6 +13,10 @@ return new class extends Migration
      */
     public function up()
     {
+        if (config('habbo.migrations.rename_tables') && Schema::hasTable('password_resets')) {
+            Schema::rename('password_resets', sprintf('password_resets_%s', time()));
+        }
+
         Schema::create('password_resets', function (Blueprint $table) {
             $table->string('email')->index();
             $table->string('token');

--- a/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
+++ b/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
@@ -13,6 +13,10 @@ return new class extends Migration
      */
     public function up()
     {
+        if (config('habbo.migrations.rename_tables') && Schema::hasTable('failed_jobs')) {
+            Schema::rename('failed_jobs', sprintf('failed_jobs_%s', time()));
+        }
+
         Schema::create('failed_jobs', function (Blueprint $table) {
             $table->id();
             $table->string('uuid')->unique();

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -13,6 +13,10 @@ return new class extends Migration
      */
     public function up()
     {
+        if (config('habbo.migrations.rename_tables') && Schema::hasTable('personal_access_tokens')) {
+            Schema::rename('personal_access_tokens', sprintf('personal_access_tokens_%s', time()));
+        }
+
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->id();
             $table->morphs('tokenable');

--- a/database/migrations/2022_08_01_181153_create_activity_log_table.php
+++ b/database/migrations/2022_08_01_181153_create_activity_log_table.php
@@ -8,6 +8,10 @@ class CreateActivityLogTable extends Migration
 {
     public function up()
     {
+        if (config('habbo.migrations.rename_tables') && Schema::hasTable(config('activitylog.table_name'))) {
+            Schema::rename(config('activitylog.table_name'), sprintf('%s_%s', config('activitylog.table_name'), time()));
+        }
+
         Schema::connection(config('activitylog.database_connection'))->create(config('activitylog.table_name'), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('log_name')->nullable();

--- a/database/migrations/2022_08_01_204744_create_table_website_settings.php
+++ b/database/migrations/2022_08_01_204744_create_table_website_settings.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up()
     {
+        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_settings')) {
+            Schema::rename('website_settings', sprintf('website_settings_%s', time()));
+        }
+
         Schema::create('website_settings', function (Blueprint $table) {
             $table->id();
             $table->string('key')->unique();

--- a/database/migrations/2022_08_01_225834_create_website_articles_table.php
+++ b/database/migrations/2022_08_01_225834_create_website_articles_table.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up()
     {
+        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_articles')) {
+            Schema::rename('website_articles', sprintf('website_articles_%s', time()));
+        }
+
         Schema::create('website_articles', function (Blueprint $table) {
             $table->id();
             $table->string('slug')->unique();

--- a/database/migrations/2022_08_04_171615_create_website_languages_table.php
+++ b/database/migrations/2022_08_04_171615_create_website_languages_table.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up()
     {
+        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_languages')) {
+            Schema::rename('website_languages', sprintf('website_languages_%s', time()));
+        }
+
         Schema::create('website_languages', function (Blueprint $table) {
             $table->id();
             $table->string('country_code', 8)->unique();

--- a/database/migrations/2022_08_06_022347_add_referral_code_to_users_table.php
+++ b/database/migrations/2022_08_06_022347_add_referral_code_to_users_table.php
@@ -10,14 +10,16 @@ return new class extends Migration {
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            Schema::table('users', function (Blueprint $table) {
-                $table->string('referral_code')->nullable()->unique()->after('home_room');
-            });
-
-            foreach (User::all() as $user) {
-                $user->update(['referral_code' => sprintf('%s%s', $user->id, Str::random(5))]);
+            if (Schema::hasColumn('users', 'referral_code')) {
+                Schema::dropColumns('users', 'referral_code');
             }
+
+            $table->string('referral_code')->nullable()->unique()->after('home_room');
         });
+
+        foreach (User::all() as $user) {
+            $user->update(['referral_code' => sprintf('%s%s', $user->id, Str::random(5))]);
+        }
     }
 
     public function down()

--- a/database/migrations/2022_08_06_022745_create_claimed_referral_logs_table.php
+++ b/database/migrations/2022_08_06_022745_create_claimed_referral_logs_table.php
@@ -7,7 +7,26 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up()
     {
-        Schema::create('claimed_referral_logs', function (Blueprint $table) {
+        $storedKeys = [];
+
+        if (config('habbo.migrations.rename_tables') && Schema::hasTable('claimed_referral_logs')) {
+
+            $keys = DB::select(DB::raw('SHOW KEYS from claimed_referral_logs'));
+
+            foreach ($keys as $key) {
+                $storedKeys[] = $key->Key_name;
+            }
+
+            if (in_array('claimed_referral_logs_user_id_index', $storedKeys)) {
+                Schema::table('claimed_referral_logs', function (Blueprint $table) {
+                    $table->dropConstrainedForeignId('user_id');
+                });
+            }
+
+            Schema::rename('claimed_referral_logs', sprintf('claimed_referral_logs_%s', time()));
+        }
+
+        Schema::create('claimed_referral_logs', function (Blueprint $table) use ($storedKeys) {
             $table->id();
             $table->integer('user_id')->index();
             $table->string('ip_address');

--- a/database/migrations/2022_08_14_210602_add_hidden_staff_to_users_table.php
+++ b/database/migrations/2022_08_14_210602_add_hidden_staff_to_users_table.php
@@ -8,6 +8,10 @@ return new class extends Migration {
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'hidden_staff')) {
+                Schema::dropColumns('users', 'hidden_staff');
+            }
+
             $table->boolean('hidden_staff')->after('rank')->default(false);
         });
     }

--- a/database/migrations/2022_08_14_210623_add_hidden_rank_to_permissions_table.php
+++ b/database/migrations/2022_08_14_210623_add_hidden_rank_to_permissions_table.php
@@ -8,6 +8,10 @@ return new class extends Migration {
     public function up()
     {
         Schema::table('permissions', function (Blueprint $table) {
+            if (Schema::hasColumn('permissions', 'hidden_rank')) {
+                Schema::dropColumns('permissions', 'hidden_rank');
+            }
+
             $table->boolean('hidden_rank')->after('rank_name')->default(false);
         });
     }

--- a/database/migrations/2022_08_25_225959_change_user_id_on_website_articles_table.php
+++ b/database/migrations/2022_08_25_225959_change_user_id_on_website_articles_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table('website_articles', function (Blueprint $table) {
+            $storedKeys = [];
+            $keys = DB::select(DB::raw('SHOW KEYS from website_articles'));
+
+            foreach ($keys as $key) {
+                $storedKeys[] = $key->Key_name;
+            }
+
+            $droppedColumn = false;
+            if (in_array('website_articles_user_id_foreign', $storedKeys)) {
+                Schema::table('website_articles', function (Blueprint $table) {
+                    $table->dropConstrainedForeignId('user_id');
+                });
+
+                $droppedColumn = true;
+            }
+
+            if ($droppedColumn || !Schema::hasColumn('website_articles', 'user_id')) {
+                $table->addColumn('integer', 'user_id')->after('full_story');
+                $table->foreign('user_id')->references('id')->on('users')->constrained()->cascadeOnDelete();
+            } else {
+                $table->integer('user_id')->change();
+            }
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('website_articles', function (Blueprint $table) {
+        });
+    }
+};


### PR DESCRIPTION
This PR adds the option to enable automatic renaming of colliding table names as well as dropping similar named foreign keys.

To enable this feature simply head to ".env" and set RENAME_COLLIDING_TABLES to true