### PR TITLE
:sparkles: Add option to convert md5 passwords to bcrypt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,3 +91,8 @@ EXTERNAL_TEXTS=gamedata/external_flash_texts.txt
 EXTERNAL_VARIABLES=gamedata/external_variables.txt
 EXTERNAL_OVERRIDE_TEXTS=gamedata/override/external_flash_override_texts.txt
 EXTERNAL_OVERRIDE_VARIABLES=gamedata/override/external_override_variables.txt
+
+# Only enable if you come from a CMS like RevCMS
+# This will only work if your password is hashed using md5
+# By default Atom CMS uses bcrypt, this is purely used to ease the process, when switching from a CMS using md5
+CONVERT_PASSWORDS=false

--- a/config/habbo.php
+++ b/config/habbo.php
@@ -39,6 +39,7 @@ return [
         'site_url' => env('APP_URL', 'http://localhost'),
         'recaptcha_site_key' => env('GOOGLE_RECAPTCHA_SITE_KEY'),
         'recaptcha_secret_key' => env('GOOGLE_RECAPTCHA_SECRET_KEY'),
+        'convert_passwords' => env('CONVERT_PASSWORDS'),
     ],
 
     'findretros' => [


### PR DESCRIPTION
This allows you to enable the possibility to convert old md5 passwords, to bcrypt, which is used by the CMS.

This feature is useful, if you're switching from a CMS like RevCMS, where the default password hashing was md5 - which wouldn't work with Atom CMS out of the box.