### PR TITLE
:sparkles: Add option to force HTTPS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,3 +96,6 @@ EXTERNAL_OVERRIDE_VARIABLES=gamedata/override/external_override_variables.txt
 # This will only work if your password is hashed using md5
 # By default Atom CMS uses bcrypt, this is purely used to ease the process, when switching from a CMS using md5
 CONVERT_PASSWORDS=false
+
+# Enable this if your site is running through https, but you're experiencing issues with requests being made to "http"
+FORCE_HTTPS=false

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -26,6 +27,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        if (config('habbo.site.force_https')) {
+            URL::forceScheme('https');
+        }
     }
 }

--- a/config/habbo.php
+++ b/config/habbo.php
@@ -46,6 +46,7 @@ return [
         'recaptcha_site_key' => env('GOOGLE_RECAPTCHA_SITE_KEY'),
         'recaptcha_secret_key' => env('GOOGLE_RECAPTCHA_SECRET_KEY'),
         'convert_passwords' => env('CONVERT_PASSWORDS'),
+        'force_https' => env('FORCE_HTTPS'),
     ],
 
     'findretros' => [

--- a/config/habbo.php
+++ b/config/habbo.php
@@ -46,7 +46,7 @@ return [
         'recaptcha_site_key' => env('GOOGLE_RECAPTCHA_SITE_KEY'),
         'recaptcha_secret_key' => env('GOOGLE_RECAPTCHA_SECRET_KEY'),
         'convert_passwords' => env('CONVERT_PASSWORDS'),
-        'force_https' => env('FORCE_HTTPS'),
+        'force_https' => env('FORCE_HTTPS', false),
     ],
 
     'findretros' => [


### PR DESCRIPTION
Some webservers struggled to make https requests sometimes, eg on article reactions. This forces every request to https if enabled.