### PR TITLE
WIP: Multiple forms on a page causing issues with errors

### DIFF
--- a/config/habbo.php
+++ b/config/habbo.php
@@ -15,9 +15,9 @@ return [
     'rcon' => [
         'host' => env('RCON_HOST', '127.0.0.1'),
         'port' => env('RCON_PORT', 3001),
-        'domain' => AF_INET,
-        'type' => SOCK_STREAM,
-        'protocol' => SOL_TCP,
+        'domain' => env('AF_INET'),
+        'type' => env('SOCK_STREAM'),
+        'protocol' => env('SOL_TCP'),
     ],
 
     'client' => [

--- a/resources/themes/atom/views/components/auth/login-modal.blade.php
+++ b/resources/themes/atom/views/components/auth/login-modal.blade.php
@@ -19,19 +19,19 @@
                     @csrf
 
                     <div>
-                        <x-form.label for="username">
+                        <x-form.label for="popup_username">
                             {{ __('Username') }}
                         </x-form.label>
 
-                        <x-form.input name="username" placeholder="{{ __('Username') }}" :autofocus="true" />
+                        <x-form.input name="popup_username" placeholder="{{ __('Username') }}" :autofocus="true" />
                     </div>
 
                     <div>
-                        <x-form.label for="password">
+                        <x-form.label for="popup_password">
                             {{ __('Password') }}
                         </x-form.label>
 
-                        <x-form.input name="password" placeholder="{{ __('Password') }}" type="password" />
+                        <x-form.input name="popup_password" placeholder="{{ __('Password') }}" type="password" />
                     </div>
 
                     @if(setting('google_recaptcha_enabled'))


### PR DESCRIPTION
Forms nested inside modals can cause issues when pages share input names with the form modal. Prefixing these form names can help mitigate this issue from happening.

**Changes**
- Updated login-modal.blade to have the 'popup' prefix for all its input forms.
- Updated LoginRequest to accept the prefix to authenticate the user.

**Testing**
Validated locally that users could register/login and that form errors don't bleed through from one form to another.

**Todo**
Look into named error bags and refactor how the login modal handles errors to avoid prefixing.