### PR TITLE
🐛 Fix Session id as non-numeric primary key.

### DIFF
--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -7,4 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 class Session extends Model
 {
     protected $guarded = ['id'];
+
+    public $incrementing = false;
 }


### PR DESCRIPTION
This fixes the session modal not parsing the id as a string.