### PR TITLE
🐛 Fix light & darkmode being toggled by system settings

### DIFF
--- a/resources/themes/atom/tailwind.config.js
+++ b/resources/themes/atom/tailwind.config.js
@@ -8,6 +8,8 @@ module.exports = {
         "./resources/**/*.js",
     ],
 
+    darkMode: 'class',
+
     theme: {
         extend: {
             fontFamily: {


### PR DESCRIPTION
By adding line in  config file tailwind will ignore default system pref when going to light mode so it does not stick to being 50/50 dark light and now also works on chrome and operaGX(I think did't test opera)