### PR TITLE
✨  Remove join Discord button when link is null

### DIFF
--- a/resources/themes/atom/views/components/user/discord-widget.blade.php
+++ b/resources/themes/atom/views/components/user/discord-widget.blade.php
@@ -8,7 +8,7 @@
     </x-slot:under-title>
 
     <div class=" text-sm dark:text-gray-200">
-        <div id="guildUsers" class="min-h-[120px] max-h-[130px] overflow-auto"> </div>
+        <div id="guildUsers" class="h-[129px] overflow-auto"> </div>
         <a id="guildInvite" target="blank">
             <x-form.secondary-button classes="mt-3">
                 {{ __('Join server') }}
@@ -108,6 +108,7 @@
                         //Checks if join server link is null and removes btn form webpage
                         if (data.instant_invite === null) {
                             document.getElementById('guildInvite').remove()
+                            document.getElementById('guildUsers').style.height = "176px"
                         } else {
                             //Gives the "Join server" button an href to the default selected chennel in the server
                             //link is recived from widget json

--- a/resources/themes/atom/views/components/user/discord-widget.blade.php
+++ b/resources/themes/atom/views/components/user/discord-widget.blade.php
@@ -104,10 +104,15 @@
 
                             document.getElementById('guildUsers').appendChild(container)
                         }
-                        //gives the "Join server" button an href to the default selected chennel in the server
-                        //link is recived from widget json
-                        document.getElementById('guildInvite').setAttribute('href', data.instant_invite)
 
+                        //Checks if join server link is null and removes btn form webpage
+                        if (data.instant_invite === null) {
+                            document.getElementById('guildInvite').remove()
+                        } else {
+                            //Gives the "Join server" button an href to the default selected chennel in the server
+                            //link is recived from widget json
+                            document.getElementById('guildInvite').setAttribute('href', data.instant_invite)
+                        }
                     })
                 });
         }


### PR DESCRIPTION
Again a rebuild is needed since i again changed some styling this pull will remove the "Join server" button on the discord widget when there is chosen for No Invite in the discord widget settings it also fixes the height of the widget when button is removed