### PR TITLE
Eagerload furniture items on rare values

### DIFF
--- a/app/Http/Controllers/WebsiteRareValuesController.php
+++ b/app/Http/Controllers/WebsiteRareValuesController.php
@@ -15,7 +15,7 @@ class WebsiteRareValuesController extends Controller
     public function index(): View
     {
         return view('rare-values', [
-            'categories' => WebsiteRareValueCategory::orderBy('priority')->with('furniture')->get(),
+            'categories' => WebsiteRareValueCategory::orderBy('priority')->with('furniture.item')->get(),
             'categoriesNav' => WebsiteRareValueCategory::all(),
         ]);
     }


### PR DESCRIPTION
The view of the rare values index page does a lot of queries because we haven't loaded furniture.items.

Resolving this through the controller